### PR TITLE
feat: add configuration switcher

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,13 +3,11 @@ from sys import stderr
 
 from dotenv import load_dotenv
 
-from bridgewatcher.db.seed.run import seed_if_needed_sync
 from bridgewatcher.discord import bot
 from bridgewatcher.loggers import load_logging_config
 
 
 def main() -> None:
-    seed_if_needed_sync()
     load_logging_config()
     load_dotenv()
 

--- a/src/bridgewatcher/db/seed/run.py
+++ b/src/bridgewatcher/db/seed/run.py
@@ -10,6 +10,7 @@ from aiohttp import ClientSession
 from bridgewatcher.api.model import Cities
 from bridgewatcher.db import db
 from bridgewatcher.db.schema import Version, Item, CraftingRequirement, ItemName
+from bridgewatcher.loggers import LOGGER
 
 ITEMS_URL = "https://raw.githubusercontent.com/ao-data/ao-bin-dumps/refs/heads/master/items.json"
 ITEM_NAMES_URL = "https://raw.githubusercontent.com/ao-data/ao-bin-dumps/refs/heads/master/formatted/items.txt"
@@ -200,7 +201,6 @@ async def seed_items_collection() -> None:
     for category_items in dump_items.values():
         items = []
         for category_item in category_items:
-            print(f"Attempting to insert {category_item["@uniquename"]}")
             # this is the most stupid shit ive ever done, messing up with the types
             # of the variable but hey, python allows me to write shitty code, why not
             # to get used to it ;)
@@ -292,15 +292,14 @@ async def seed_if_needed(forced: bool = False) -> None:
         if version_doc is not None:
             version = Version.from_mongo(version_doc)
             if version.hash == current_hash:
-                print("Hashes match. No seeding will run")
+                LOGGER.info("Hashes match. No seeding will run")
                 return
     else:
-        print("Forced seeding detected")
+        LOGGER.info("Forced seeding detected")
 
-    print("Seeding the database")
+    LOGGER.info("Seeding the database")
     await seed()
     await update_hash(current_hash)
-    print("Seeding complete")
 
 
 def seed_if_needed_sync(forced: bool = False) -> None:

--- a/src/bridgewatcher/discord/__init__.py
+++ b/src/bridgewatcher/discord/__init__.py
@@ -4,6 +4,7 @@ from typing import override
 from discord import Intents
 from discord.ext.commands import Bot
 
+from bridgewatcher.db.seed.run import seed_if_needed
 from bridgewatcher.loggers import LOGGER
 
 
@@ -19,6 +20,9 @@ class Bridgewatcher(Bot):
 
     @override
     async def setup_hook(self) -> None:
+        LOGGER.info("Running seeding checks...")
+        await seed_if_needed()
+
         LOGGER.info("Loading commands from cogs...")
         await self._load_cogs()
 

--- a/src/bridgewatcher/discord/cogs/ext.py
+++ b/src/bridgewatcher/discord/cogs/ext.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timezone
 
-from discord.app_commands import command
+from discord.app_commands import Choice, check, choices, command, describe, guild_only
 from discord.ext.commands import Bot, Cog
-from discord import Interaction
+from discord import Guild, Interaction
+
+from bridgewatcher.api import AlbionOnlineServers
+from bridgewatcher.discord.util import md, ServerManager
 
 
 class Ext(Cog):
@@ -13,7 +16,32 @@ class Ext(Cog):
     async def show_utc(self, interaction: Interaction) -> None:
         now = datetime.now(timezone.utc)
         await interaction.response.send_message(
-            f"Currently it's {now.hour}:{now.minute} in Albion Online"
+            f"Currently it's {md.bold(f"{now.hour}:{now.minute}")} in Albion Online"
+        )
+
+    @command(name="conf", description="Shows Bridgewatcher configuration")
+    @guild_only()
+    @check(lambda ctx: ctx.guild is not None)
+    async def show_conf(self, interaction: Interaction) -> None:
+        guild: Guild = interaction.guild  # type: ignore
+        conf = await ServerManager.get_or_create_conf(guild)
+        await interaction.response.send_message(
+            f"Bridgewatcher is set up for working with {md.bold(conf.fetch_server.capitalize())} server"
+        )
+
+    @command(name="server", description="Sets Bridgewatcher working server")
+    @describe(server="Albion Online working server")
+    @choices(
+        server=[Choice(name=server, value=server) for server in AlbionOnlineServers]
+    )
+    @guild_only()
+    @check(lambda ctx: ctx.guild is not None)
+    async def set_server(self, interaction: Interaction, server: Choice[str]) -> None:
+        guild: Guild = interaction.guild  # type: ignore
+        fetch_server = AlbionOnlineServers.from_str(server.value)
+        conf = await ServerManager.get_or_update_conf(guild, fetch_server)
+        await interaction.response.send_message(
+            f"Successfully updated working server to {md.bold(conf.fetch_server.capitalize())}"
         )
 
 

--- a/src/bridgewatcher/discord/cogs/ext.py
+++ b/src/bridgewatcher/discord/cogs/ext.py
@@ -16,7 +16,7 @@ class Ext(Cog):
     async def show_utc(self, interaction: Interaction) -> None:
         now = datetime.now(timezone.utc)
         await interaction.response.send_message(
-            f"Currently it's {md.bold(f"{now.hour}:{now.minute}")} in Albion Online"
+            f"Currently it's {md.bold(f"{now.hour}:{now.minute:02d}")} in Albion Online"
         )
 
     @command(name="conf", description="Shows Bridgewatcher configuration")

--- a/src/bridgewatcher/discord/events/guild.py
+++ b/src/bridgewatcher/discord/events/guild.py
@@ -1,7 +1,7 @@
 from discord import Guild
 
 from bridgewatcher.discord import bot
-from bridgewatcher.discord.util.guild import ServerManager
+from bridgewatcher.discord.util import ServerManager
 from bridgewatcher.loggers import LOGGER
 
 

--- a/src/bridgewatcher/discord/util/__init__.py
+++ b/src/bridgewatcher/discord/util/__init__.py
@@ -1,0 +1,9 @@
+from .guild import ServerManager
+from .md import Markdown
+
+md = Markdown()
+
+__all__ = (
+    "md",
+    "ServerManager",
+)

--- a/src/bridgewatcher/discord/util/__init__.py
+++ b/src/bridgewatcher/discord/util/__init__.py
@@ -1,4 +1,4 @@
-from .guild import ServerManager
+from .server import ServerManager
 from .md import Markdown
 
 md = Markdown()

--- a/src/bridgewatcher/discord/util/md.py
+++ b/src/bridgewatcher/discord/util/md.py
@@ -11,7 +11,7 @@ class Markdown:
     def bold_italic(self, s: Any) -> str:
         return f"***{str(s)}***"
 
-    def codeblock(self, s: Any) -> str:
+    def inline_code(self, s: Any) -> str:
         return f"`{str(s)}`"
 
     def underline(self, s: Any) -> str:

--- a/src/bridgewatcher/discord/util/md.py
+++ b/src/bridgewatcher/discord/util/md.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+
+class Markdown:
+    def italic(self, s: Any) -> str:
+        return f"*{str(s)}*"
+
+    def bold(self, s: Any) -> str:
+        return f"**{str(s)}**"
+
+    def bold_italic(self, s: Any) -> str:
+        return f"***{str(s)}***"
+
+    def codeblock(self, s: Any) -> str:
+        return f"`{str(s)}`"
+
+    def underline(self, s: Any) -> str:
+        return f"__{str(s)}__"
+
+    def strikethrough(self, s: Any) -> str:
+        return f"~~{str(s)}~~"
+
+    def spoiler(self, s: Any) -> str:
+        return f"||{str(s)}||"

--- a/src/bridgewatcher/discord/util/server.py
+++ b/src/bridgewatcher/discord/util/server.py
@@ -1,32 +1,38 @@
 from discord import Guild
 
-from bridgewatcher.api import AlbionOnlineServers
+from bridgewatcher.api import AlbionOnline, AlbionOnlineServers
 from bridgewatcher.db import db
 from bridgewatcher.db.schema import DiscordServer
 
 
 class ServerManager:
-    @staticmethod
-    async def create_conf(guild: Guild) -> DiscordServer:
+    @classmethod
+    async def get_albion(cls, guild: Guild) -> AlbionOnline:
+        conf = await cls.get_or_create_conf(guild)
+        server = AlbionOnlineServers.from_str(conf.fetch_server)
+        return AlbionOnline(server)
+
+    @classmethod
+    async def create_conf(cls, guild: Guild) -> DiscordServer:
         server = DiscordServer(guild.id, AlbionOnlineServers.AMERICA.value)
         servers = db.get_collection("discord_servers")
         await servers.insert_one(server.to_mongo())
         return server
 
-    @staticmethod
-    async def get_or_create_conf(guild: Guild) -> DiscordServer:
+    @classmethod
+    async def get_or_create_conf(cls, guild: Guild) -> DiscordServer:
         servers = db.get_collection("discord_servers")
         server = await servers.find_one({"id": guild.id})
         if server is not None:
             return DiscordServer.from_mongo(server)
 
-        return await ServerManager.create_conf(guild)
+        return await cls.create_conf(guild)
 
-    @staticmethod
+    @classmethod
     async def get_or_update_conf(
-        guild: Guild, fetch_server: AlbionOnlineServers
+        cls, guild: Guild, fetch_server: AlbionOnlineServers
     ) -> DiscordServer:
-        server = await ServerManager.get_or_create_conf(guild)
+        server = await cls.get_or_create_conf(guild)
         server.fetch_server = fetch_server
         servers = db.get_collection("discord_servers")
         await servers.update_one(
@@ -35,7 +41,7 @@ class ServerManager:
         )
         return server
 
-    @staticmethod
-    async def delete_conf(guild: Guild) -> None:
+    @classmethod
+    async def delete_conf(cls, guild: Guild) -> None:
         servers = db.get_collection("discord_servers")
         await servers.delete_one({"id": guild.id})

--- a/src/bridgewatcher/discord/util/server.py
+++ b/src/bridgewatcher/discord/util/server.py
@@ -30,7 +30,8 @@ class ServerManager:
         server.fetch_server = fetch_server
         servers = db.get_collection("discord_servers")
         await servers.update_one(
-            filter={"id": guild.id}, update={"fetch_server": server.fetch_server}
+            filter={"id": guild.id},
+            update={"$set": {"fetch_server": server.fetch_server}},
         )
         return server
 


### PR DESCRIPTION
Let's see a Rabbit review on this pull request.

## Added
* `ServerManager` class with utilities to get `DiscordServer` and `AlbionOnline` instances easily.
* `/conf` and `/server` commands to read and write discord server configuration respectively.
* `Markdown` class for generating markdown.

## Changed:
* Seeding is now done in `Bridgewatcher.setup_hook()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guild-only slash commands to view and manage per-server settings, including selecting the active Albion Online server.
  * Enhanced response formatting, including emphasized time display styling.
* **Improvements**
  * Database seeding checks now run during bot startup with cleaner, consistent logging.
  * Server configuration updates are applied more reliably and stored correctly.
  * Added support for retrieving the configured Albion Online connection per server.
* **Bug Fixes**
  * Fixed configuration update behavior to prevent unintended overwriting of stored settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->